### PR TITLE
Added the ability to add "data-random-from-set" attribute to the iframe

### DIFF
--- a/agenda-portal/boot/assets/preview-test-canvas.html
+++ b/agenda-portal/boot/assets/preview-test-canvas.html
@@ -13,6 +13,7 @@
         <iframe
           data-oa-preview="http://localhost:3000/preview"
           data-count="3"
+          data-random-from-set="20"
           data-lang="fr"
           data-target-url="http://localhost:3000/iframe-test-canvas.html"
           data-target-iframe

--- a/agenda-portal/client/lib/iframe.parent.js
+++ b/agenda-portal/client/lib/iframe.parent.js
@@ -95,11 +95,26 @@ module.exports = (iframe, options = {}) => {
 
   // This iframe parent should track base and
 
-  if (iframe.getAttribute('data-count')) {
+  if (iframe.getAttribute('data-count') && !iframe.getAttribute('data-random-from-set')) {
     relative = appendAttributeValueToQuery(
       iframe,
       relative,
       'limit',
+      'data-count'
+    );
+  }
+
+  if (iframe.getAttribute('data-count') && iframe.getAttribute('data-random-from-set')) {
+    relative = appendAttributeValueToQuery(
+      iframe,
+      relative,
+      'limit',
+      'data-random-from-set'
+    );
+    relative = appendAttributeValueToQuery(
+      iframe,
+      relative,
+      'subsetRandom',
       'data-count'
     );
   }

--- a/agenda-portal/index.js
+++ b/agenda-portal/index.js
@@ -19,6 +19,7 @@ const error = require('./middleware/error');
 const eventMiddlewares = require('./middleware/event');
 const { redirectToNeighbor } = require('./middleware/eventNavigation');
 const list = require('./middleware/listEvents');
+const randomFromSet = require('./middleware/randomFromSet');
 const pageGlobals = require('./middleware/pageGlobals');
 const renderSelection = require('./middleware/renderSelection');
 const webpackSASSMiddleware = require('./dev/webpackSASSMiddleware');
@@ -34,6 +35,7 @@ const mw = {
   event: eventMiddlewares,
   redirectToNeighbor,
   list,
+  randomFromSet,
   preview: renderSelection('preview'),
   pageGlobals,
   redirectLegacyEventQuery,
@@ -179,6 +181,7 @@ module.exports = async options => {
     '/preview',
     mw.pageGlobals.withOptions({ mainScript: 'preview.js', iframable: true }),
     mw.list,
+    mw.randomFromSet,
     middlewareHooks.preview.preRender,
     mw.preview
   );

--- a/agenda-portal/middleware/randomFromSet.js
+++ b/agenda-portal/middleware/randomFromSet.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const _ = require('lodash');
+const shuffleArray = require('../utils/shuffleArray');
+//const qs = require('qs');
+
+module.exports = (req, res, next) => {
+
+  if(req.query && req.query.subsetRandom){
+    shuffleArray(req.data.events);
+    req.data = _.assign(req.data || {}, {
+      events: req.data.events.slice(0, req.query.subsetRandom)
+    });
+  }
+  
+  next();
+};

--- a/agenda-portal/utils/shuffleArray.js
+++ b/agenda-portal/utils/shuffleArray.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = (array) => {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}


### PR DESCRIPTION
This allows users to pick a random subset out of a larger set of events.
Syntax:
```
<iframe
          data-oa-preview="http://localhost:3000/preview"
          data-count="3"
          data-query="oaq[featured]=1"
          data-random-from-set="20"
          data-lang="fr"
          data-target-url="http://localhost:3000/iframe-test-canvas.html"
          data-target-iframe
          allowtransparency="allowtransparency"
          frameborder="0"></iframe>
```